### PR TITLE
Switch to yt-dlp from youtube-dl

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@ Please visit the [project homepage](https://dxli94.github.io/WLASL/) for news up
 
 Please **star the repo** to help with the visibility if you find it useful.
 
+**yt-dlp vs youtube-dl** youtube-dl has had low maintance for a while now and does not work for some youtube videos, see this [issue](https://github.com/ytdl-org/youtube-dl/issues/30568).
+[yt-dlp](https://github.com/yt-dlp/yt-dlp) is a more up to date fork, which seems to work for all youtube videos. Therefore `./start_kit/video_downloader.py` uses yt-dlp by default but can be switched back to youtube-dl in the future by adjusting the `youtube_downloader` variable.
+If you have trouble with yt-dlp make sure update to the latest version, as Youtube is constantly changing.
+
 Download Original Videos
 -----------------
 1. Download repo.

--- a/start_kit/video_downloader.py
+++ b/start_kit/video_downloader.py
@@ -11,6 +11,9 @@ import logging
 logging.basicConfig(filename='download_{}.log'.format(int(time.time())), filemode='w', level=logging.DEBUG)
 logging.getLogger().addHandler(logging.StreamHandler(sys.stdout))
 
+# Set this to youtube-dl if you want to use youtube-dl.
+# The the README for an explanation regarding yt-dlp vs youtube-dl.
+youtube_downloader = "yt-dlp"
 
 def request_video(url, referer=''):
     user_agent = 'Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:1.9.0.7) Gecko/2009021910 Firefox/3.0.7'
@@ -100,10 +103,9 @@ def download_nonyt_videos(indexfile, saveto='raw_videos'):
 
 
 def check_youtube_dl_version():
-    ver = os.popen('youtube-dl --version').read()
+    ver = os.popen(f'{youtube_downloader} --version').read()
 
-    assert ver, "youtube-dl cannot be found in PATH. Please verify your installation."
-    assert ver >= '2020.03.08', "Please update youtube-dl to newest version."
+    assert ver, f"{youtube_downloader} cannot be found in PATH. Please verify your installation."
 
 
 def download_yt_videos(indexfile, saveto='raw_videos'):
@@ -127,7 +129,7 @@ def download_yt_videos(indexfile, saveto='raw_videos'):
                 logging.info('YouTube videos {} already exists.'.format(video_url))
                 continue
             else:
-                cmd = "youtube-dl \"{}\" -o \"{}%(id)s.%(ext)s\""
+                cmd = f"{youtube_downloader} \"{{}}\" -o \"{{}}%(id)s.%(ext)s\""
                 cmd = cmd.format(video_url, saveto + os.path.sep)
 
                 rv = os.system(cmd)


### PR DESCRIPTION
Addresses: #56

./start_kit/video_downloader.py was not working with some youtube
videos, due to youtube-dl out of date.

Therefore this commit updates ./start_kit/video_downloader.py to use yt-dlp which is
a more up to date fork of youtube-dl.

It looks like youtube-dl is under new maintenance and may become
viable in the future. Therefore the youtube_downloader variable can be
changes in ./start_kit/video_downloader.py to easily switch between the two.

Relevant github issue for youtube-dl status: https://github.com/ytdl-org/youtube-dl/issues/30568
